### PR TITLE
Added support for single breakend notation

### DIFF
--- a/R/AllUtilities.R
+++ b/R/AllUtilities.R
@@ -115,7 +115,8 @@
 {
     grepl("<", x, fixed=TRUE) |
     grepl("[", x, fixed=TRUE) |
-    grepl("]", x, fixed=TRUE) 
+    grepl("]", x, fixed=TRUE) |
+    grepl(".", x, fixed=TRUE)
 }
 
 .formatInfo <- function(x, hdr, nrecords)


### PR DESCRIPTION
VCFv4.3 section 5.4.9 defines a single breakend notation which uses `.` to signify a breakend with an unknown partner. Currently, VariantAnnotation attempts to load these variants as a DNAStringSet which results in ALT of all breakend variants being removed when loading the VCF.