### PR TITLE
moved vcfFields() from 'SimpleList()' into 'CharacterList()'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Annotation of Genetic Variants
 Description: Annotate variants, compute amino acid coding changes,
         predict coding outcomes.
-Version: 1.27.5
+Version: 1.27.6
 Authors@R: c(person("Valerie", "Obenchain", role=c("aut", "cre"),
         email="maintainer@bioconductor.org"),
     person("Martin", "Morgan", role="aut"),

--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,7 @@ CHANGES IN VERSION 1.27.5
 NEW FEATURES
 
     o Add vcfFields method for character, VCFHeader, VcfFile and VCF
-    to return all available vcf fields.
+    to return all available vcf fields in CharacterList().
 
 CHANGES IN VERSION 1.24.0
 ------------------------

--- a/R/methods-VCFHeader-class.R
+++ b/R/methods-VCFHeader-class.R
@@ -130,11 +130,11 @@ function(x)
 ## vcfFields
 setMethod("vcfFields", "VCFHeader", function(x, ...)
 {
-    SimpleList(fixed = names(fixed(x)), 
-               info = rownames(info(x)),
-               geno = rownames(geno(x)),
-               samples = samples(x)
-               )
+    CharacterList(fixed = names(fixed(x)), 
+                  info = rownames(info(x)),
+                  geno = rownames(geno(x)),
+                  samples = samples(x)
+                  )
 })
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/inst/unitTests/test_vcfFields.R
+++ b/inst/unitTests/test_vcfFields.R
@@ -1,4 +1,4 @@
-test_VcfFile_vcfFields <- function(){
+test_vcfFields <- function(){
 
     ## empty
     checkException(vcfFields(), silent = TRUE)
@@ -10,7 +10,7 @@ test_VcfFile_vcfFields <- function(){
     flds <- vcfFields(fl)
 
     checkTrue(validObject(flds))
-    checkTrue(is(flds, "SimpleList"))
+    checkTrue(is(flds, "CharacterList"))
     checkIdentical(names(flds), c("fixed", "info", "geno", "samples"))
 
     ## signatures

--- a/man/VCF-class.Rd
+++ b/man/VCF-class.Rd
@@ -238,10 +238,10 @@
       }
     }
     \item{}{\code{vcfFields(x)}
-      Returns a SimpleList of all available VCF fields, with names of
-      \code{fixed}, \code{info}, \code{geno} and \code{samples}
-      indicating the four categories. Each element is a character() vector
-      of available VCF field names within each category. 
+      Returns a \code{\link[IRanges]{CharacterList}} of all available VCF
+      fields, with names of \code{fixed}, \code{info}, \code{geno} and
+      \code{samples} indicating the four categories. Each element is a
+      character() vector of available VCF field names within each category. 
     }
   }
 }

--- a/man/VCFHeader-class.Rd
+++ b/man/VCFHeader-class.Rd
@@ -99,12 +99,11 @@
     }
     \item{}{
       \code{vcfFields(x)}:
-      Returns a SimpleList of all available VCF fields, with names of
-      \code{fixed}, \code{info}, \code{geno} and \code{samples}
-      indicating the four categories. Each element is a character() vector
-      of available VCF field names within each category. 
+      Returns a \code{\link[IRanges]{CharacterList}} of all available VCF
+      fields, with names of \code{fixed}, \code{info}, \code{geno} and
+      \code{samples} indicating the four categories. Each element is a
+      character() vector of available VCF field names within each category. 
     }
-    
   }
 }
 

--- a/man/VcfFile-class.Rd
+++ b/man/VcfFile-class.Rd
@@ -133,10 +133,10 @@
   ## Methods:
   \describe{
     \item{vcfFields}{
-      Returns a SimpleList of all available VCF fields, with names of
-      \code{fixed}, \code{info}, \code{geno} and \code{samples}
-      indicating the four categories. Each element is a character() vector
-      of available VCF field names within each category. 
+      Returns a \code{\link[IRanges]{CharacterList}} of all available VCF
+      fields, with names of \code{fixed}, \code{info}, \code{geno} and
+      \code{samples} indicating the four categories. Each element is a
+      character() vector of available VCF field names within each category.
     }
   }
 }


### PR DESCRIPTION
Hi @vobencha , 

This new pull request has changed the returned value from `vcfFields()` into a `SimpleCharacterList`. Please take a look. Thanks!

Best,
Qian