### PR TITLE
expand: expand any variables with Number set to 'R' into REF/ALT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.o
 *.so
+.project

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Annotation of Genetic Variants
 Description: Annotate variants, compute amino acid coding changes,
         predict coding outcomes.
-Version: 1.29.0
+Version: 1.29.1
 Authors@R: c(person("Valerie", "Obenchain", role=c("aut", "cre"),
         email="maintainer@bioconductor.org"),
     person("Martin", "Morgan", role="aut"),
@@ -27,3 +27,4 @@ LazyLoad: yes
 biocViews: DataImport, Sequencing, SNP, Annotation,
         Genetics, VariantAnnotation
 Video: https://www.youtube.com/watch?v=Ro0lHQ_J--I&list=UUqaMSQd_h-2EDGsU6WDiX0Q
+RoxygenNote: 6.1.1

--- a/R/methods-expand.R
+++ b/R/methods-expand.R
@@ -13,9 +13,15 @@ setMethod("expand", "CollapsedVCF",
         if (all(elt == 1L)) {
             fxd <- fixed(x)
             fxd$ALT <- unlist(alt(x), use.names=FALSE)
-            AD <- "AD" %in% names(geno(x))
-            if (AD)
-              geno(x)$AD <- .expandAD(geno(x)$AD, nrow(x), ncol(x))
+			ghdr <- geno(header(x))
+			isR <- rownames(ghdr) == "AD" | ghdr$Number == "R"
+            if (any(isR)){
+            	varsR <- rownames(ghdr)[isR]
+				geno(x)[varsR] <- endoapply(
+					geno(x)[varsR], function(i)
+					.expandAD(i, nrow(x), ncol(x))
+				)
+		  	}
             return(VCF(rd, colData(x), metadata(x), fxd, .unlistAltInfo(x), 
                        geno(x), ..., collapsed=FALSE))
         }
@@ -67,28 +73,30 @@ setMethod("expand", "CollapsedVCF",
         }
         gvar
     }
-    ## AD field: one value for REF and each ALT
-    if (any(isAD <- names(gvar) == "AD")) {
-        AD <- gvar$AD
-        if (!is.list(AD)) {
+    ## AD (for back-compatibility) and 'Number=A' (ADF/ADR): one value for REF and each ALT
+	isR <- names(gvar) %in% c("AD", rownames(ghdr)[ghdr$Number == "R"])
+	for(i in which(isR)){
+		varR <- names(gvar)[i]
+        gvarR <- gvar[[varR]]
+        if (!is.list(gvarR)) {
             ## 'Number' is integer
-            if (is(AD, "array") && length(dim(AD)) == 3L) {
+            if (is(gvarR, "array") && length(dim(gvarR)) == 3L) {
                 if ((length(unique(elt)) != 1L) || 
-                    (dim(AD)[3] != unique(elt))) {
-                    warning("'AD' was ignored: number of 'AD' values ",
+                    (dim(gvarR)[3] != unique(elt))) {
+                    warning("'", varR, "' was ignored: number of '", varR, "' values ",
                             "do not match REF + ALT")
-                    isAD[isAD] <- FALSE 
+					isR[i] <- FALSE 
                 }
             } else {
-               isAD[isAD] <- FALSE 
+				isR[i] <- FALSE 
             }
         } else {
-            ## 'Number' is '.'
-            gvar$AD <- .expandAD(AD, length(idx), ncol(x))
+            ## 'Number' is '.' or 'R'
+            gvar[[varR]] <- .expandAD(gvarR, length(idx), ncol(x))
         }
-    }
-    isA <- names(gvar) %in% rownames(ghdr)[isA]
-    gvar[!isA & !isAD] <- endoapply(gvar[!isA & !isAD], function(i) {
+	}
+	isA <- names(gvar) %in% rownames(ghdr)[isA]
+    gvar[!isA & !isR] <- endoapply(gvar[!isA & !isR], function(i) {
                               if (is(i, "matrix")) {
                                   matrix(i[idx, ], nrow=length(idx),
                                          ncol=ncol(x))

--- a/inst/unitTests/cases/ex1-seq1-90.vcf
+++ b/inst/unitTests/cases/ex1-seq1-90.vcf
@@ -1,0 +1,26 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##bcftoolsVersion=1.9+htslib-1.9
+##bcftoolsCommand=mpileup -Q 0 -d 1000000 --annotate FORMAT/AD,FORMAT/ADF,FORMAT/ADR --no-reference -r seq1:90 --output-type v --output ex1-seq1:90.vcf ex1.bam
+##contig=<ID=seq1,length=1575>
+##contig=<ID=seq2,length=1584>
+##ALT=<ID=*,Description="Represents allele(s) other than observed.">
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=IDV,Number=1,Type=Integer,Description="Maximum number of reads supporting an indel">
+##INFO=<ID=IMF,Number=1,Type=Float,Description="Maximum fraction of reads supporting an indel">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Raw read depth">
+##INFO=<ID=VDB,Number=1,Type=Float,Description="Variant Distance Bias for filtering splice-site artefacts in RNA-seq data (bigger is better)",Version="3">
+##INFO=<ID=RPB,Number=1,Type=Float,Description="Mann-Whitney U test of Read Position Bias (bigger is better)">
+##INFO=<ID=MQB,Number=1,Type=Float,Description="Mann-Whitney U test of Mapping Quality Bias (bigger is better)">
+##INFO=<ID=BQB,Number=1,Type=Float,Description="Mann-Whitney U test of Base Quality Bias (bigger is better)">
+##INFO=<ID=MQSB,Number=1,Type=Float,Description="Mann-Whitney U test of Mapping Quality vs Strand Bias (bigger is better)">
+##INFO=<ID=SGB,Number=1,Type=Float,Description="Segregation based metric.">
+##INFO=<ID=MQ0F,Number=1,Type=Float,Description="Fraction of MQ0 reads (smaller is better)">
+##INFO=<ID=I16,Number=16,Type=Float,Description="Auxiliary tag used for calling, see description of bcf_callret1_t in bam2bcf.h">
+##INFO=<ID=QS,Number=R,Type=Float,Description="Auxiliary tag used for calling">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="List of Phred-scaled genotype likelihoods">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths">
+##FORMAT=<ID=ADF,Number=R,Type=Integer,Description="Allelic depths on the forward strand">
+##FORMAT=<ID=ADR,Number=R,Type=Integer,Description="Allelic depths on the reverse strand">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	ex1.bam
+seq1	90	.	N	G,A,C,<*>	0	.	DP=13;I16=0,0,13,0,0,0,260,6110,0,0,714,41636,0,0,114,1218;QS=0,0.946502,0.0288066,0.0246914,0;VDB=0.314346;SGB=-0.683931;MQ0F=0	PL:ADF:ADR:AD	105,33,0,107,25,104,108,25,107,105,105,33,107,108,105:0,11,1,1,0:0,0,0,0,0:0,11,1,1,0

--- a/inst/unitTests/test_expand-methods.R
+++ b/inst/unitTests/test_expand-methods.R
@@ -62,3 +62,30 @@ test_expand_gvcf <- function()
     checkIdentical(dim(geno(exp)$AD), c(7L, 1L, 2L))
     checkIdentical(geno(exp)$AD[,,1], as.integer(c(NA, 17, 17, NA, 20, 20, NA)))
 }
+
+
+test_expand_adr_adf <- function()
+{
+	fl <- system.file("unitTests", "cases", "ex1-seq1-90.vcf", package = "VariantAnnotation")
+	vcf <- readVcf(fl, genome = "")
+	exp <- expand(vcf)
+	seqName <- "seq1:90_N/G";sampleName <- colnames(vcf)[1]
+	
+	# for all/forward/revert strands
+	tmp <- sapply(c("AD", "ADF", "ADR"), function(var){
+		
+		# original counts
+		countsVcf <- geno(vcf)[[var]][seqName, sampleName][[1]]
+				
+		# in VCF: counts reported first for reference, then alternative alleles
+		# check counts for reference allele
+		checkTrue(all(geno(exp)[[var]][, sampleName, 1] == countsVcf[1]))
+		
+		# check if counts for alternative alleles
+		idxMatch <- match(alt(vcf)[[1]], alt(exp))
+		countsExpand <- geno(exp)[[var]][idxMatch, sampleName, 2]
+		checkIdentical(countsExpand, countsVcf[-1]) 
+
+	})
+
+}

--- a/man/VCF-class.Rd
+++ b/man/VCF-class.Rd
@@ -291,7 +291,8 @@
       \code{expand(x, ..., row.names = FALSE)}:
       Expand (unlist) the ALT column of a CollapsedVCF object to one row 
       per ALT value. Variables with Number='A' have one value per alternate
-      allele and are expanded accordingly. The 'AD' genotype field
+      allele and are expanded accordingly. The 'AD' genotype field (and any
+      variables with 'Number' set to 'R')
       is expanded into REF/ALT pairs. For all other fields, the rows
       are replicated to match the elementNROWS of ALT.
 


### PR DESCRIPTION
The current `expand` function only expands the AD genotype field to ALT/REF pairs.
It would be useful to also expand any FORMAT field with information field Number set to 'R', which also contains one value for each possible allele (including the reference) as mentioned in [VCF documentation](https://samtools.github.io/hts-specs/VCFv4.2.pdf).
I encounter this scenario when annotating also the allele depth in the forward/revert strand with the `samtools mpileup` function with `--annotate FORMAT/AD,FORMAT/ADF,FORMAT/ADR` in SamTools >= 1.3.
Example:
```{}
geno(header(vcf)):
       Number Type    Description                              
   PL  G      Integer List of Phred-scaled genotype likelihoods
   AD  R      Integer Allelic depths                           
   ADF R      Integer Allelic depths on the forward strand     
   ADR R      Integer Allelic depths on the reverse strand  
# CollapsedVCF
rowRanges(vcf[idx, ])
GRanges object with 1 range and 5 metadata columns:
               seqnames    ranges strand | paramRangeID            REF             ALT      QUAL      FILTER
                  <Rle> <IRanges>  <Rle> |     <factor> <DNAStringSet> <CharacterList> <numeric> <character>
  GeneI:69_G/T    GeneI        69      * |         <NA>              G           T,A,C         0           .
geno(vcf)$ADR[idx, ]
[[1]]
[1] 3534 8698    1    1
```
Please let me know if there is an alternative way to retrieve/expand the same information.
Thanks in advance!
