### PR TITLE
rewriting the `vcfFields,character` to have remote VCF filepath work

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Annotation of Genetic Variants
 Description: Annotate variants, compute amino acid coding changes,
         predict coding outcomes.
-Version: 1.29.2
+Version: 1.29.3
 Authors@R: c(person("Valerie", "Obenchain", role=c("aut", "cre"),
         email="maintainer@bioconductor.org"),
     person("Martin", "Morgan", role="aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Annotation of Genetic Variants
 Description: Annotate variants, compute amino acid coding changes,
         predict coding outcomes.
-Version: 1.29.0
+Version: 1.29.1
 Authors@R: c(person("Valerie", "Obenchain", role=c("aut", "cre"),
         email="maintainer@bioconductor.org"),
     person("Martin", "Morgan", role="aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Annotation of Genetic Variants
 Description: Annotate variants, compute amino acid coding changes,
         predict coding outcomes.
-Version: 1.29.1
+Version: 1.29.2
 Authors@R: c(person("Valerie", "Obenchain", role=c("aut", "cre"),
         email="maintainer@bioconductor.org"),
     person("Martin", "Morgan", role="aut"),

--- a/R/methods-VcfFile.R
+++ b/R/methods-VcfFile.R
@@ -104,7 +104,7 @@ setMethod("seqinfo", "VcfFileList",
 setMethod("vcfFields", "character",
     function(x, ...)
 {
-    stopifnot(!is.na(x), all(file.exists(x)))
+    stopifnot(!is.na(x))
     hdr <- scanVcfHeader(x)
     vcfFields(hdr)
 })

--- a/R/methods-writeVcf.R
+++ b/R/methods-writeVcf.R
@@ -148,12 +148,10 @@
         header <- c(fileDate, header)
     }
     idx <- which(names(header) == "fileformat")
-    if (idx != 1) {
+    if (length(idx) && idx != 1) {
         fileformat <- header[idx] 
         header[idx] <- NULL
         header <- c(fileformat, header) 
-    } else {
-        warning("header is missing 'fileformat' field")
     }
     contig <- any(grepl("contig", names(header), fixed=TRUE))
     if (!contig)

--- a/R/methods-writeVcf.R
+++ b/R/methods-writeVcf.R
@@ -141,15 +141,24 @@
     header <- Map(.formatHeader, as.list(dflist), 
                   as.list(names(dflist)))
 
-    ## If contig, fileformat do not exist --> add them 
+    ## If fileformat, fileDate or contig do not exist --> add them 
+    fileDate <- any(grepl("fileDate", names(header), fixed=TRUE))
+    if (!fileDate) {
+        fileDate <- paste("##fileDate=", format(Sys.time(), "%Y%m%d"), sep="")
+        header <- c(fileDate, header)
+    }
+    idx <- which(names(header) == "fileformat")
+    if (idx != 1) {
+        fileformat <- header[idx] 
+        header[idx] <- NULL
+        header <- c(fileformat, header) 
+    } else {
+        warning("header is missing 'fileformat' field")
+    }
     contig <- any(grepl("contig", names(header), fixed=TRUE))
     if (!contig)
         header <- c(header, .contigsFromSeqinfo(seqinfo(obj)))
-    fileformat <- any(grepl("fileformat", names(header), fixed=TRUE))
-    if (!fileformat) {
-        fileformat <- paste("##fileformat=VCFv4.3")
-        header <- c(header, fileformat) 
-    } 
+
     ## Last line before data
     colnms <- c("#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO")
     if (length(geno(obj, withDimnames=FALSE)) > 0L) {

--- a/man/VcfFile-class.Rd
+++ b/man/VcfFile-class.Rd
@@ -138,7 +138,8 @@
       Returns a \code{\link[IRanges]{CharacterList}} of all available VCF
       fields, with names of \code{fixed}, \code{info}, \code{geno} and
       \code{samples} indicating the four categories. Each element is a
-      character() vector of available VCF field names within each category.
+      character() vector of available VCF field names within each
+      category. It works for both local and remote vcf file. 
     }
   }
 }
@@ -156,6 +157,12 @@ vcfFields(vcffile)
 param <- GRanges("7", IRanges(c(55000000,  55900000), width=10000))
 vcf <- readVcf(vcffile, "hg19", param=param)
 dim(vcf)
+
+## `vcfFields` also works for remote vcf filepath.  
+\dontrun{
+chr22url <- "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz"
+vcfFields(chr22url)
+}
 }
 
 \keyword{classes}


### PR DESCRIPTION
Hi @vobencha ,

I have just made a small change for the `vcfFields,character` so that `vcfFields` now could work for the remote vcf filepath by skipping the check of `file.exists(x)` e.g., 

```
chr22url <- "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz"
vcfFields(chr22url)
 CharacterList of length 4
 [["fixed"]] REF ALT QUAL FILTER
 [["info"]] CIEND CIPOS CS END IMPRECISE MC ... DP AA VT EX_TARGET MULTI_ALLELIC
 [["geno"]] GT
 [["samples"]] HG00096 HG00097 HG00099 HG00100 ... NA21142 NA21143 NA21144
```

However, for local files, the check could still be done inside the next line of code `hdr <- scanVcfHeader(x)`, so no need to worry about that. E.g., 

```
!> vcfFields("random/path")
 Error in .io_check_exists(path(con)) : file(s) do not exist:
   'random/path'
```

I have also synced the 2 commits from `git.bioconductor.org` on Nov. 19 and Nov 27 that are made by yourself. 

Thanks,
Qian
