### PR TITLE
Correct META API change version numbers to 1.27.5/.6

### DIFF
--- a/man/VCFHeader-class.Rd
+++ b/man/VCFHeader-class.Rd
@@ -73,13 +73,13 @@
       have no "ID" field in which case the "key" is used as the
       row name.
  
-      NOTE: In VariantAnnotation <= 1.27.25, the \code{meta()} extractor
+      NOTE: In VariantAnnotation <= 1.27.5, the \code{meta()} extractor
       returned a \code{DataFrame} called "META" which held all simple
       key-value header lines. The VCF 4.3 specs allowed headers lines
       with key name "META" which caused a name clash with the pre-existing
       "META" \code{DataFrame}. 
 
-      In \code{VariantAnnotation} >=1.27.26 the "META" \code{DataFrame} was
+      In \code{VariantAnnotation} >=1.27.6 the "META" \code{DataFrame} was
       split and each row became its own separate \code{DataFrame}. Calling
       \code{meta()} on a \code{VCFHeader} object now returns a list of
       \code{DataFrames}, one for each unique key name in the header.


### PR DESCRIPTION
Fix typo so that the discontinuity documented is at the same version number as documented in _man/writeVcf-methods.Rd_. (The final 1.27.x version was in fact 1.27.9 — it never got near 1.27.25.)

This API change occurred in 7e705e7daeec9997547cb5e8f3670ba1e4d595b1 which did indeed bump the version number to 1.27.6.