### PR TITLE
Write solo ##contig/##FILTER/etc lines as structured headers

### DIFF
--- a/R/methods-writeVcf.R
+++ b/R/methods-writeVcf.R
@@ -190,7 +190,8 @@
         }                                           # end response
         .pasteMultiFieldDF(df, nms)
     ## 'simple' key-value pairs
-    } else if(ncol(df) == 1L && nrow(df) == 1L) {
+    ## (Rsamtools reports unstructured headers as one column named "Value")
+    } else if(ncol(df) == 1L && names(df)[1] == "Value" && nrow(df) == 1L) {
         if (nms == "fileDate") {
             fd <- format(Sys.time(), "%Y%m%d")
             paste("##fileDate=", fd, sep="")


### PR DESCRIPTION
Some structured VCF headers have only one field in addition to ID: e.g., `##contig=<ID=1,length=100>` or `##FILTER=<ID=X,Description="Y">` or other user-defined structured headers. When there is only one such header line, the existing code incorrectly prints it as an unstructured header. This causes #36 and #42.

Rsamtools (currently) distinguishes 1-field structured headers from unstructured headers only by the resulting dataframe column name: either the field name (`length`/`Description`/etc) or a generic `Value` for unstructured headers.

Use this to avoid misinterpreting solo `##contig`/`##FILTER`/etc headers as simple unstructured lines.