### PR TITLE
Allow 'ANY' txdb, eg. EnsDb objects

### DIFF
--- a/R/methods-predictCoding.R
+++ b/R/methods-predictCoding.R
@@ -2,14 +2,14 @@
 ### predictCoding methods 
 ### =========================================================================
 
-setMethod("predictCoding", c("IntegerRanges", "TxDb", "ANY", "DNAStringSet"),
+setMethod("predictCoding", c("IntegerRanges", "ANY", "ANY", "DNAStringSet"),
     function(query, subject, seqSource, varAllele, ..., ignore.strand=FALSE)
 {
     callGeneric(as(query, "GRanges"), subject, seqSource, varAllele, ...,
                 ignore.strand=ignore.strand) 
 })
 
-setMethod("predictCoding", c("CollapsedVCF", "TxDb", "ANY", "missing"),
+setMethod("predictCoding", c("CollapsedVCF", "ANY", "ANY", "missing"),
     function(query, subject, seqSource, varAllele, ..., ignore.strand=FALSE)
 {
     rd <- rowRanges(query)
@@ -29,7 +29,7 @@ setMethod("predictCoding", c("CollapsedVCF", "TxDb", "ANY", "missing"),
     res 
 })
 
-setMethod("predictCoding", c("ExpandedVCF", "TxDb", "ANY", "missing"),
+setMethod("predictCoding", c("ExpandedVCF", "ANY", "ANY", "missing"),
     function(query, subject, seqSource, varAllele, ..., ignore.strand=FALSE)
 {
     if (is(alt(query), "CharacterList")) {
@@ -39,14 +39,14 @@ setMethod("predictCoding", c("ExpandedVCF", "TxDb", "ANY", "missing"),
                 ignore.strand=ignore.strand) 
 })
 
-setMethod("predictCoding", c("GRanges", "TxDb", "ANY", "DNAStringSet"),
+setMethod("predictCoding", c("GRanges", "ANY", "ANY", "DNAStringSet"),
     function(query, subject, seqSource, varAllele, ..., ignore.strand=FALSE)
 {
     .predictCoding(query, subject, seqSource, varAllele, ...,
                    ignore.strand=ignore.strand)
 })
 
-setMethod("predictCoding", c("VRanges", "TxDb", "ANY", "missing"),
+setMethod("predictCoding", c("VRanges", "ANY", "ANY", "missing"),
     function(query, subject, seqSource, varAllele, ..., ignore.strand=FALSE)
 {
     varAllele <- alt(query)


### PR DESCRIPTION
Thank for for the _VariantAnnotation_ package, it makes it very easy to annotate mutations found in VCF files!

There is, however, one limitation that I find unnecessarily restrictive: The `predictCoding` method expects a `TxDb` object as its second argument and will not be able to process gene and transcript annotations otherwise.

I propose that the limitation here should be any object that supports the `cdsBy` and `transcriptsBy` methods, e.g. an `EnsDb` object. As they do not share a common base class, I allow `ANY` type that will then error if the associated methods are not found.

In particular, the code that previously failed now works successfully:

```r
ens106 = AnnotationHub::AnnotationHub()[["AH100643"]]
asm = BSgenome.Hsapiens.NCBI.GRCh38::BSgenome.Hsapiens.NCBI.GRCh38
fname = system.file("extdata", "chr22.vcf.gz", package="VariantAnnotation")
vr = VariantAnnotation::readVcfAsVRanges(fname)
res = predictCoding(vr, ens106, asm)
# Error in (function (classes, fdef, table)  :
#   unable to find an inherited method for 'predictCoding' for signature '"VRanges", "EnsDb", "BSgenome", "missing"'
```