### PR TITLE
improve CMD check results via copilot intervention

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Annotation of Genetic Variants
 Description: Annotate variants, compute amino acid coding changes,
         predict coding outcomes.
-Version: 1.55.2
+Version: 1.55.3
 Authors@R: c(
         person("Valerie", "Oberchain", role="aut"),
         person("Martin", "Morgan", role="aut"),

--- a/man/PolyPhenDb-class.Rd
+++ b/man/PolyPhenDb-class.Rd
@@ -22,28 +22,28 @@
 \section{Methods}{
   In the code below, \code{x} is a \code{PolyPhenDb} object.
   \describe{
-    \item{}{
+    \item{metadata}{
       \code{metadata(x)}:
       Returns \code{x}'s metadata in a data frame.
     }
-    \item{}{
+    \item{columns}{
       \code{columns(x)}:
       Returns the names of the \code{columns} that can be used to subset the
       data columns. For column descriptions see \code{?PolyPhenDbColumns}.
     }
-    \item{}{
+    \item{keys}{
       \code{keys(x)}:
       Returns the names of the \code{keys} that can be used to subset the
       data rows. The \code{keys} values are the rsid's.
     }
-    \item{}{
+    \item{select}{
       \code{select(x, keys = NULL, columns = NULL, ...)}:
       Returns a subset of data defined by the character vectors \code{keys} 
       and \code{columns}. If no \code{keys} are supplied, all rows are
       returned. If no \code{columns} are supplied, all columns
       are returned. See \code{?PolyPhenDbColumns} for column descriptions.
     } 
-    \item{}{
+    \item{duplicateRSID}{
       \code{duplicateRSID(x)}:
       Returns a named list of duplicate rsid groups. The names are the 
       \code{keys}, the list elements are the rsid's that have been 

--- a/man/SIFTDb-class.Rd
+++ b/man/SIFTDb-class.Rd
@@ -21,21 +21,21 @@
 \section{Methods}{
   In the code below, \code{x} is a \code{SIFTDb} object.
   \describe{
-    \item{}{
+    \item{metadata}{
       \code{metadata(x)}:
       Returns \code{x}'s metadata in a data frame.
     }
-    \item{}{
+    \item{columns}{
       \code{columns(x)}:
       Returns the names of the \code{columns} that can be used to subset the
       data columns.
     }
-    \item{}{
+    \item{keys}{
       \code{keys(x)}:
       Returns the names of the \code{keys} that can be used to subset the
       data rows. The \code{keys} values are the rsid's.
     }
-    \item{}{
+    \item{select}{
       \code{select(x, keys = NULL, columns = NULL, ...)}:
       Returns a subset of data defined by the character vectors \code{keys} 
       and \code{columns}. If no \code{keys} are supplied, all rows are

--- a/man/VCF-class.Rd
+++ b/man/VCF-class.Rd
@@ -104,10 +104,10 @@
 
 \section{Constructors}{
   \describe{
-    \item{}{
+    \item{readVcf}{
       \code{readVcf(file, genome, param, ..., row.names=TRUE)}
     }
-    \item{}{
+    \item{VCF}{
       \code{VCF(rowRanges = GRanges(), colData = DataFrame(), 
                 exptData = list(header = VCFHeader()), 
                 fixed = DataFrame(), info = DataFrame(), 
@@ -126,7 +126,7 @@
   In the following code snippets \code{x} is a CollapsedVCF or ExpandedVCF 
   object.
   \describe{
-    \item{}{
+    \item{rowRanges}{
       \code{rowRanges(x, ..., fixed = TRUE)}, \code{rowRanges(x) <- value}:
       Gets or sets the rowRanges. The CHROM, POS, ID, POS and REF fields are
       used to create a \code{GRanges} object. The start of the ranges are
@@ -147,46 +147,42 @@
 
       The metadata columns of a VCF object are accessed with the following:
       \itemize{
-        \item{\code{ref(x)}, \code{ref(x) <- value}:
+        \item \code{ref(x)}, \code{ref(x) <- value}:
           Gets or sets the reference allele (REF). \code{value} must 
           be a \code{DNAStringSet}. 
-        }
-        \item{\code{alt(x)}, \code{alt(x) <- value}:
+        \item \code{alt(x)}, \code{alt(x) <- value}:
           Gets or sets the alternate allele data (ALT). When \code{x} is 
           a CollapsedVCF, \code{value} must be a \code{DNAStringSetList}
           or \code{CompressedCharacterList}. For ExpandedVCF, \code{value}
           must be a \code{DNAStringSet} or \code{character}.
-        }
-        \item{\code{qual(x)}, \code{qual(x) <- value}:
+        \item \code{qual(x)}, \code{qual(x) <- value}:
           Returns or sets the quality scores (QUAL). \code{value} must 
           be an \code{numeric(1L)}.
-        }
-        \item{\code{filt(x)}, \code{filt(x) <- value}:
+        \item \code{filt(x)}, \code{filt(x) <- value}:
           Returns or sets the filter data. \code{value} must 
           be a \code{character(1L)}. Names must be one of 'REF', 'ALT',
           'QUAL' or 'FILTER'.
-        }
       }
     }
-    \item{}{
+    \item{mcols}{
       \code{mcols(x)}, \code{mcols(x) <- value}:
        These methods behave the same as \code{mcols(rowRanges(x))} and 
        \code{mcols(rowRanges(x)) <- value}. This method does not manage the
        fixed fields, 'REF', 'ALT', 'QUAL' or 'FILTER'. To modify those
        columns use \code{fixed<-}.
     }
-    \item{}{
+    \item{fixed}{
       \code{fixed(x)}, \code{fixed(x) <- value}:
        Gets or sets a DataFrame of REF, ALT, QUAL and FILTER only. 
        Note these fields are displayed as metadata columns with
        the rowRanges() data (set to fixed = FALSE to suppress).
     }
-    \item{}{
+    \item{info}{
       \code{info(x, ..., row.names = TRUE)}, \code{info(x) <- value}:
        Gets or sets a DataFrame of INFO variables. Row names are added
        if unique and \code{row.names=TRUE}.
     }
-    \item{}{
+    \item{geno}{
       \code{geno(x, withDimnames=TRUE)}, \code{geno(x) <- value}:
        oets a SimpleList of genotype data.
        \code{value} is a SimpleList. To replace a single variable in
@@ -195,36 +191,36 @@
        row names are returned; to override specify
        \code{geno(vcf, withDimnames=FALSE)}.
     }
-    \item{}{
+    \item{metadata}{
       \code{metadata(x)}:
        Gets a \code{list} of experiment-related data. By default this
        list includes the \sQuote{header} information from the VCF file. 
        See the use of \code{header()} for details in extracting
        header information. 
     }
-    \item{}{
+    \item{colData}{
       \code{colData(x)}, \code{colData(x) <- value}:
       Gets or sets a \code{DataFrame} of sample-specific information. Each row 
       represents a sample in the VCF file. \code{value} must be a 
       \code{DataFrame} with rownames representing the samples in the VCF 
       file.
     }
-    \item{}{
+    \item{genome}{
       \code{genome(x)}:
       Extract the \code{genome} information from the \code{GRanges} object
       returned by the \code{rowRanges} accessor.
     }
-    \item{}{
+    \item{seqlevels}{
       \code{seqlevels(x)}:
       Extract the \code{seqlevels} from the \code{GRanges} object
       returned by the \code{rowRanges} accessor.
     }
-    \item{}{
+    \item{strand}{
       \code{strand(x)}:
       Extract the \code{strand} from the \code{GRanges} object
       returned by the \code{rowRanges} accessor.
     }
-    \item{}{
+    \item{header}{
       \code{header(x)}, \code{header(x)<- value}:
       Get or set the VCF header information. Replacement value
       must be a \code{VCFHeader} object. To modify individual elements 
@@ -232,13 +228,13 @@
       \sQuote{VCFHeader} object. See ?\code{VCFHeader} man page for
       details.
        \itemize{
-         \item{\code{info(header(x))}}
-         \item{\code{geno(header(x))}}
-         \item{\code{meta(header(x))}}
-         \item{\code{samples(header(x))}}
+         \item \code{info(header(x))}
+         \item \code{geno(header(x))}
+         \item \code{meta(header(x))}
+         \item \code{samples(header(x))}
       }
     }
-    \item{}{\code{vcfFields(x)}
+    \item{vcfFields}{\code{vcfFields(x)}
       Returns a \code{\link[IRanges]{CharacterList}} of all available VCF
       fields, with names of \code{fixed}, \code{info}, \code{geno} and
       \code{samples} indicating the four categories. Each element is a
@@ -251,12 +247,12 @@
   In the following code \code{x} is a VCF object, and \dots is a list
   of VCF objects.
   \describe{
-    \item{}{
+    \item{[}{
       \code{x[i, j]}, \code{x[i, j] <- value}: Gets or sets rows and columns.
       \code{i} and \code{j} can be integer or logical vectors. \code{value} is a
       replacement \code{VCF} object.
     }
-    \item{}{
+    \item{subset}{
       \code{subset(x, subset, select, ...)}: Restricts \code{x} by
       evaluating the \code{subset} argument in the scope of
       \code{rowData(x)} and \code{info(x)}, and \code{select} in the
@@ -264,7 +260,7 @@
       by rows, while the \code{select} argument restricts by column. The
       \code{\dots} are passed to the underlying \code{subset()} calls.
     }
-    \item{}{
+    \item{cbind, rbind}{
       \code{cbind(...)}, \code{rbind(...)}: \code{cbind} combines objects with
       identical ranges (\code{rowRanges}) but different samples (columns in
       \code{assays}). The colnames in \code{colData} must match or an error is
@@ -288,7 +284,7 @@
 \section{expand}{
   In the following code snippets \code{x} is a CollapsedVCF object.
   \describe{
-    \item{}{
+    \item{expand}{
       \code{expand(x, ..., row.names = FALSE)}:
       Expand (unlist) the ALT column of a CollapsedVCF object to one row 
       per ALT value. Variables with Number='A' have one value per alternate

--- a/man/VCFHeader-class.Rd
+++ b/man/VCFHeader-class.Rd
@@ -44,7 +44,7 @@
 
 \section{Constructor}{
   \describe{
-    \item{}{
+    \item{VCFHeader}{
       \code{VCFHeader(reference = character(), samples = character(), 
                       header = DataFrameList(), ...)
       }
@@ -55,16 +55,16 @@
 \section{Accessors}{
   In the following code snippets \code{x} is a VCFHeader object.
   \describe{
-    \item{}{
+    \item{samples}{
       \code{samples(x)}:
       Returns a character() vector of names of samples. 
     }
-    \item{}{
+    \item{header}{
       \code{header(x)}:
       Returns all information in the header slot which includes
       \code{meta}, \code{info} and \code{geno} if present.
     }
-    \item{}{
+    \item{meta}{
       \code{meta(x)}, \code{meta(x)<- value}: The getter returns a
       \code{DataFrameList}. Each \code{DataFrame} represents a unique
       "key" name in the header file. Multiple header lines
@@ -84,7 +84,7 @@
       \code{meta()} on a \code{VCFHeader} object now returns a list of
       \code{DataFrames}, one for each unique key name in the header.
     }
-    \item{}{
+    \item{fixed}{
       \code{fixed(x), fixed(x)<- value}:
       Returns a \code{DataFrameList} of information pertaining to any of
       \sQuote{REF}, \sQuote{ALT}, \sQuote{FILTER} and \sQuote{QUAL}. 
@@ -92,24 +92,24 @@
       the following names, \sQuote{QUAL}, \sQuote{FILTER}, \sQuote{REF} 
       and \sQuote{ALT}. 
     }
-    \item{}{
+    \item{info}{
       \code{info(x)}, \code{info(x)<- value}:
       Gets or sets a \code{DataFrame} of \sQuote{INFO} information.
       Replacement value must be a \code{DataFrame} with 3 columns
       named \sQuote{Number}, \sQuote{Type} and \sQuote{Description}. 
     }
-    \item{}{
+    \item{geno}{
       \code{geno(x)}, \code{geno(x)<- value}:
       Returns a \code{DataFrame} of \sQuote{FORMAT} information.
       Replacement value must be a \code{DataFrame} with 3 columns
       named \sQuote{Number}, \sQuote{Type} and \sQuote{Description}. 
     }
-    \item{}{
+    \item{reference}{
       \code{reference(x)}:
       Returns a character() vector with names of reference sequences.
       Not relevant for \code{scanVcfHeader}.
     }
-    \item{}{
+    \item{vcfFields}{
       \code{vcfFields(x)}:
       Returns a \code{\link[IRanges]{CharacterList}} of all available VCF
       fields, with names of \code{fixed}, \code{info}, \code{geno} and

--- a/man/VRanges-class.Rd
+++ b/man/VRanges-class.Rd
@@ -143,7 +143,7 @@
 
 \section{Constructors}{
   \describe{
-    \item{}{
+    \item{VRanges}{
       \code{VRanges(seqnames = Rle(), ranges = IRanges(), ref = character(), 
         alt = NA_character_, totalDepth = NA_integer_, refDepth = NA_integer_, 
         altDepth = NA_integer_, ..., sampleNames = NA_character_, 
@@ -163,7 +163,7 @@
           reference read depth (NA allowed).}
         \item{\code{altDepth}}{integer vector/Rle, containing the
           reference read depth (NA allowed).}
-        \item{\code{\ldots}}{Arguments passed to the \code{GRanges}
+        \item{\code{...}}{Arguments passed to the \code{GRanges}
           constructor.}
         \item{\code{sampleNames}}{character/factor vector/Rle, containing the
           sample names (NA allowed).}
@@ -176,7 +176,7 @@
           subset the object to its current state.}
       }
     }
-    \item{}{
+    \item{makeVRangesFromGRanges}{
       \code{makeVRangesFromGRanges(gr, 
                                    ref.field="ref",
                                    alt.field="alt",
@@ -229,7 +229,7 @@
   These functions/methods coerce objects to and from \code{VRanges}:
  
   \describe{
-    \item{}{
+    \item{asVCF}{
       \code{asVCF(x, info = character(), filter = character(), meta =
         character())}: Creates a VCF object from a VRanges object. The
       following gives the mapping from VRanges components to VCF:
@@ -263,10 +263,10 @@
       logical column with the reverse coercion. There are many other
       cases of irreversibility.
     }
-    \item{}{
+    \item{as(from, "VCF")}{
       \code{as(from, "VCF")}: Like calling \code{asVCF(from)}.
     }
-    \item{}{
+    \item{as(from, "VRanges")}{
       \code{as(from, "VRanges")}:
       When \code{from} is a \code{VCF} this coercion is essentially
       the inverse of \code{asVCF}. Information missing in the VCF
@@ -287,44 +287,44 @@
   provides the following, where \code{x} is a VRanges object.
 
   \describe{
-    \item{}{
+    \item{alt}{
       \code{alt(x), alt(x) <- value}: Get or set the alt allele (character).
     }
-    \item{}{
+    \item{ref}{
       \code{ref(x), ref(x) <- value}: Get or set the ref allele (character).
     }
-    \item{}{
+    \item{altDepth}{
       \code{altDepth(x), altDepth(x) <- value}: Get or set the alt allele
       read depth (integer).
     }
-    \item{}{
+    \item{refDepth}{
       \code{refDepth(x), refDepth(x) <- value}: Get or set the ref
       allele read depth (integer).
     }
-    \item{}{
+    \item{totalDepth}{
       \code{totalDepth(x), totalDepth(x) <- value}: Get or set the total
       read depth (integer).
     }
-    \item{}{
+    \item{altFraction}{
       \code{altFraction(x)}: Returns \code{altDepth(x)/totalDepth(x)} (numeric).
     }
-    \item{}{
+    \item{sampleNames}{
       \code{sampleNames(x), sampleNames(x) <- value}: Get or set the
       sample names (character/factor).
     }
-    \item{}{
+    \item{softFilterMatrix}{
       \code{softFilterMatrix(x), softFilterMatrix(x) <- value}: Gets or
       sets the soft filter matrix (any matrix, but ideally a
       \code{FilterMatrix}).
     }
-    \item{}{
+    \item{resetFilter}{
       \code{resetFilter(x)}: Removes all columns from \code{softFilterMatrix}.
     }
-    \item{}{
+    \item{called}{
       \code{called(x)}: Returns whether all filter results in
       \code{softFilterMatrix(x)} are \code{TRUE} for each variant.
     }
-    \item{}{
+    \item{hardFilters}{
       \code{hardFilters(x), hardFilters(x) <- value}: Gets or
       sets the hard filters (those applied to yield the current subset).
     }
@@ -333,16 +333,16 @@
 
 \section{Utilities and Conveniences}{
   \describe{
-    \item{}{
+    \item{match}{
       \code{match(x)}: Like GRanges \code{match}, except matches on the
       combination of chromosome, start, width, and \strong{alt}.
     }
-    \item{}{
+    \item{tabulate}{
       \code{tabulate(bin)}: Finds \code{unique(bin)} and counts how many
       times each unique element occurs in \code{bin}. The result is
       stored in \code{mcols(bin)$sample.count}.
     }
-    \item{}{
+    \item{softFilter}{
       \code{softFilter(x, filters, ...)}: applies the \code{FilterRules}
       in \code{filters} to \code{x}, storing the results in
       \code{softFilterMatrix}.
@@ -352,11 +352,11 @@
 
 \section{Input/Output to/from VCF}{
   \describe{
-    \item{}{
+    \item{writeVcf}{
       \code{writeVcf(obj, filename, ...)}: coerces to a VCF object and
       writes it to a file; see \code{\link{writeVcf}}.
     }
-    \item{}{
+    \item{readVcfAsVRanges}{
       \code{readVcfAsVRanges(x, genome, param = ScanVcfParam(), ...)}:
       Reads a VCF \code{x} directly into a \code{VRanges};
       see \code{\link{readVcf}} for details on the arguments.

--- a/man/VRangesList-class.Rd
+++ b/man/VRangesList-class.Rd
@@ -32,7 +32,7 @@
 
 \section{Constructor}{
   \describe{
-    \item{}{
+    \item{VRangesList}{
       \code{VRangesList(...)}:
       Creates a VRangesList object from \code{VRanges} objects in \dots.
     }
@@ -41,11 +41,11 @@
 
 \section{Accessors}{
   \describe{
-    \item{}{
+    \item{alt}{
       \code{alt(x)}: Returns a CharacterList or RleList, effectively by
       calling \code{alt(x[[i]])} on each element of \code{x}.
     }
-    \item{}{
+    \item{ref}{
       \code{ref(x)}:
       Returns a CharacterList, effectively by calling \code{ref(x[[i]])}
       on each element of \code{x}.
@@ -55,7 +55,7 @@
 
 \section{Utilities}{
   \describe{
-    \item{}{
+    \item{stackSamples}{
       \code{stackSamples(x)}: Concentrates the elements in \code{x},
       using \code{names(x)} to appropriately fill \code{sampleNames} in
       the result.

--- a/man/VariantType-class.Rd
+++ b/man/VariantType-class.Rd
@@ -131,28 +131,28 @@
   In the following code, \code{x} is a \code{PromoterVariants} or a
   \code{AllVariants} object.
   \describe{
-    \item{}{
+    \item{upstream}{
       \code{upstream(x)}, \code{upstream(x) <- value}:
       Gets or sets the number of base pairs defining a range
       upstream of the 5' end (excludes 5' start value).
     }
-    \item{}{
+    \item{downstream}{
       \code{downstream(x)}, \code{downstream(x) <- value}:
       Gets or sets the number of base pairs defining a range
       downstream of the 3' end (excludes 3' end value).
     }
-    \item{}{
+    \item{idType}{
       \code{idType(x)}, \code{idType(x) <- value}:
       Gets or sets the \code{character()} which controls the id returned 
       in the PRECEDEID and FOLLOWID output columns. Possible values are
       "gene" and "tx".
     }
-    \item{}{
+    \item{promoters}{
       \code{promoters(x)}, \code{promoters(x) <- value}:
       Gets or sets the \code{PromoterVariants} in the 
       \code{AllVariants} object.
     }
-    \item{}{
+    \item{intergenic}{
       \code{intergenic(x)}, \code{intergenic(x) <- value}:
       Gets or sets the \code{IntergenicVariants} in the 
       \code{AllVariants} object.

--- a/man/VcfFile-class.Rd
+++ b/man/VcfFile-class.Rd
@@ -28,50 +28,50 @@
   
   ## Constructors
   \describe{
-    \item{}{
+    \item{VcfFile}{
       VcfFile(file, index = paste(file, "tbi", sep="."), ...,
       yieldSize=NA_integer_)
     }
-    \item{}{
+    \item{VcfFileList}{
       VcfFileList(..., yieldSize=NA_integer_)
     }
   }
   
   ## Accessors
   \describe{
-    \item{}{
+    \item{index}{
       index(object)}
-    \item{}{
+    \item{path}{
       path(object, ...)}
-    \item{}{
+    \item{isOpen}{
       isOpen(con, rw="")}
-    \item{}{
+    \item{yieldSize}{
       yieldSize(object, ...)}
-    \item{}{
+    \item{yieldSize<-}{
       yieldSize(object, ...) <- value}
-    \item{}{
+    \item{show}{
       show(object)
     }
   }
   
   ## Opening / closing
   \describe{
-    \item{}{
+    \item{open}{
       open(con, ...)}
-    \item{}{
+    \item{close}{
       close(con, ...)}
   }
   
   ## method
   \describe{
-    \item{}{
+    \item{vcfFields}{
       vcfFields(object)
     }
   }
 }
 
 \section{arguments}{
-  \itemize{
+  \describe{
     \item{con}{An instance of \code{VcfFile}.}
 
     \item{file}{A character(1) vector to the Vcf file

--- a/man/defunct.Rd
+++ b/man/defunct.Rd
@@ -43,33 +43,17 @@
 
   ## Removed
   \itemize{
-    \item{
-      \code{refLocsToLocalLocs} has been replaced by \code{mapToTranscripts}
+    \item \code{refLocsToLocalLocs} has been replaced by \code{mapToTranscripts}
       and \code{pmapToTranscripts}.
-    }
-    \item{
-      \code{readVcfLongForm} has been replaced by \code{expand}.
-    }
-    \item{
-      \code{dbSNPFilter} and \code{regionFilter} have been replaced by 
+    \item \code{readVcfLongForm} has been replaced by \code{expand}.
+    \item \code{dbSNPFilter} and \code{regionFilter} have been replaced by 
       \code{filterVcf}.
-    }
-    \item{
-      \code{regionFilter} has been replaced by \code{filterVcf}.
-    }
-    \item{
-      \code{MatrixToSnpMatrix} has been replaced by \code{genotypeToSnpMatrix}.
-    }
-    \item{ 
-      \code{getTranscriptSeqs} has been replaced by
+    \item \code{regionFilter} has been replaced by \code{filterVcf}.
+    \item \code{MatrixToSnpMatrix} has been replaced by \code{genotypeToSnpMatrix}.
+    \item \code{getTranscriptSeqs} has been replaced by
       \code{extractTranscriptSeqs} in the GenomicFeatures package.
-    }
-    \item{
-      \code{VRangesScanVcfParam} has been replaced by \code{ScanVcfParam}.
-    }
-    \item{
-      \code{restrictToSVN} has been replaced by \code{isSNV}.
-    }
+    \item \code{VRangesScanVcfParam} has been replaced by \code{ScanVcfParam}.
+    \item \code{restrictToSVN} has been replaced by \code{isSNV}.
   }
 }
 

--- a/man/genotypeToSnpMatrix-methods.Rd
+++ b/man/genotypeToSnpMatrix-methods.Rd
@@ -43,10 +43,10 @@
   "GT", "GP", "GL" or "PL" FORMAT field of a VCF file into a 
   \link[snpStats:SnpMatrix-class]{SnpMatrix}. The following caveats apply, 
   \itemize{
-    \item{no distinction is made between phased and unphased genotypes}
-    \item{variants with >1 ALT allele are set to NA}
-    \item{only single nucleotide variants are included; others are set to NA}
-    \item{only diploid calls are included; others are set to NA}
+    \item no distinction is made between phased and unphased genotypes
+    \item variants with >1 ALT allele are set to NA
+    \item only single nucleotide variants are included; others are set to NA
+    \item only diploid calls are included; others are set to NA
   }
 
   In VCF files, 0 represents the reference allele and integers greater than 0
@@ -62,21 +62,21 @@
   
   The genotype fields are defined as follows:
   \itemize{
-    \item{GT : genotype, encoded as allele values separated by either of
+    \item GT : genotype, encoded as allele values separated by either of
       "/" or "|". The allele values are 0 for the reference allele and 1
-      for the alternate allele.}
-    \item{GL : genotype likelihoods comprised of comma separated
+      for the alternate allele.
+    \item GL : genotype likelihoods comprised of comma separated
       floating point log10-scaled likelihoods for all possible
       genotypes.  In the case of a reference allele A and a single
       alternate allele B, the likelihoods will be ordered "A/A", "A/B",
-      "B/B".}
-    \item{PL : the phred-scaled genotype likelihoods rounded to the
+      "B/B".
+    \item PL : the phred-scaled genotype likelihoods rounded to the
       closest integer.  The ordering of values is the 
-      same as for the GL field.}
-    \item{GP : the phred-scaled genotype posterior probabilities for all
+      same as for the GL field.
+    \item GP : the phred-scaled genotype posterior probabilities for all
       possible genotypes; intended to store
       imputed genotype probabilities.  The ordering of values is the
-      same as for the GL field.}
+      same as for the GL field.
   }
 
   If \code{uncertain=TRUE}, the posterior probabilities of the three

--- a/man/isSNV-methods.Rd
+++ b/man/isSNV-methods.Rd
@@ -96,7 +96,7 @@
   All functions return a logical vector the length of \code{x}.
   Variants in gvcf files with NON_REF alt alleles return TRUE;
   structural variants return FALSE.
-  \itemize{
+  \describe{
     \item{isSNV: }{
       Reference and alternate alleles are both a single nucleotide long.
     }

--- a/man/readVcf-methods.Rd
+++ b/man/readVcf-methods.Rd
@@ -60,7 +60,7 @@ readGT(file, nucleotides=FALSE, param=ScanVcfParam(), ..., row.names=TRUE)
     and ?\code{indexVcf} for help creating a \code{\link{VcfFile}}.
   }
   \item{genome}{A \code{character} or \code{Seqinfo} object.
-    \itemize{
+    \describe{
       \item{\code{character}:}{ Genome identifier as a single string or named 
         character vector. Names of the character vector correspond to 
         chromosome names in the file. This identifier replaces the genome 

--- a/man/summarizeVariants-methods.Rd
+++ b/man/summarizeVariants-methods.Rd
@@ -71,7 +71,7 @@
   be transcripts-by-sample. If the \code{GRangesList} is genes,
   the count matrix will be gene-by-sample.
 
-  \itemize{
+  \describe{
     \item{Counting with locateVariants() :}{
 
       Variant counts are always summarized transcript-by-sample.

--- a/man/writeVcf-methods.Rd
+++ b/man/writeVcf-methods.Rd
@@ -26,7 +26,7 @@
   }
   \item{\dots}{Additional arguments, passed to methods.
       \itemize{
-        \item{nchunk:} Integer or NA. When provided this argument
+        \item nchunk: Integer or NA. When provided this argument
         overrides the default chunking behavior of \code{writeVcf}, 
         see Details section. An integer value specifies the number
         of records in each chunk; NA disables chunking.


### PR DESCRIPTION
After manually correcting the errors in unitTests arising from using 3.22 annotations,
warnings persisted because of poor Rd formatting.  I asked the github coding agent to
correct these and the warnings have gone away.  A review would be helpful.