### PR TITLE
fix: writeVcf restores '*' spanning deletion in multi-allele ALT (#65)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Annotation of Genetic Variants
 Description: Annotate variants, compute amino acid coding changes,
         predict coding outcomes.
-Version: 1.59.0
+Version: 1.59.1
 Authors@R: c(
         person("Valerie", "Oberchain", role="aut"),
         person("Martin", "Morgan", role="aut"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,18 @@
+CHANGES IN VERSION 1.59.1
+-------------------------
+
+BUG FIXES
+
+    o writeVcf() now restores '*' (spanning deletion) alleles in multi-
+      allele ALT fields instead of writing empty alleles that produce
+      malformed VCF lines (e.g. "CA,,TTA" instead of "CA,*,TTA"). This
+      fixes IGV/htsjdk errors ("empty alleles are not permitted in VCF
+      records") when opening files written by VariantAnnotation.
+      Note: the ambiguous single-allele case (ALT='*' vs ALT='.') cannot
+      be resolved at write time due to read-time representation loss;
+      a future fix at the C parsing level would fully resolve this.
+      (GitHub issue #65)
+
 CHANGES IN VERSION 1.36.0
 -------------------------
 

--- a/R/methods-writeVcf.R
+++ b/R/methods-writeVcf.R
@@ -39,6 +39,28 @@
     if (is(ALT, "XStringSetList")) {
         ALT <- as(ALT, "CharacterList")
     }
+    ## Restore '*' for spanning deletion alleles stored as empty strings
+    ## at read time (GitHub issue #65). Per VCF spec, '*' represents a
+    ## spanning deletion allele. At read time, both '*' and '.' (no allele)
+    ## get converted to empty strings, making them indistinguishable.
+    ## Conservative fix: only restore '*' when an empty string appears
+    ## alongside other alleles (multi-allele context), since that's
+    ## unambiguously a spanning deletion. A lone empty string is written
+    ## as '.' to preserve monomorphic reference site semantics.
+    if (is(ALT, "CharacterList") || is(ALT, "List")) {
+        ALT <- endoapply(ALT, function(a) {
+            empty <- !is.na(a) & nchar(a) == 0L
+            if (any(empty) && length(a) > 1L)
+                a[empty] <- "*"
+            a
+        })
+    } else if (is.character(ALT)) {
+        ## ExpandedVCF: scalar character per row — ambiguous case.
+        ## These are already expanded so a single '*' would have been
+        ## the only allele for that row. Write as '*' since expand()
+        ## doesn't produce monomorphic rows.
+        ALT[!is.na(ALT) & nchar(ALT) == 0L] <- "*"
+    }
     ALT <- as.character(unstrsplit(ALT, ","))
     ALT[nchar(ALT) == 0L | is.na(ALT)] <- "."
     if (is.null(QUAL <- qual(obj)))


### PR DESCRIPTION
## Summary

Partially fixes #65.

`writeVcf()` now correctly writes `*` (spanning deletion) alleles in multi-allele ALT fields instead of producing empty alleles that make the VCF malformed.

## Problem

As reported in #65, writing a VCF with spanning deletions produced output like:
```
chr1  10150  .  CTA  CA,,TTA  ...
```
instead of:
```
chr1  10150  .  CTA  CA,*,TTA  ...
```

The empty allele caused IGV/htsjdk to reject the file with:
> empty alleles are not permitted in VCF records

## Root Cause

`readVcf()` converts `*` to empty strings at parse time (in `.formatALT()`), losing the distinction between `*` (spanning deletion) and `.` (no allele). At write time, these empty strings were collapsed into empty fields.

## Fix

At write time (`.makeVcfMatrix()`), before collapsing ALT alleles with `unstrsplit`, restore `*` for empty strings that appear in multi-allele list elements (`length > 1`). An empty string alongside other alleles is unambiguously a spanning deletion per VCF spec. For `ExpandedVCF` objects (scalar ALT per row), empty strings also become `*` since `expand()` doesn't produce monomorphic rows.

## Limitations

The ambiguous single-allele case (a sole `*` vs `.`) cannot be fully resolved at write time because the C-level parser erases the distinction. This PR conservatively writes `.` for that case. A complete fix would require changes to the C parsing layer as @hpages discussed in the issue thread.

## Testing

- All existing writeVcf tests pass
- Verified manually: `CA,*,TTA` is correctly round-tripped through read/write

## Agentic tooling disclosure

This PR was produced with the assistance of Kiro CLI (Amazon's AI coding agent). All changes were reviewed and verified by the author.